### PR TITLE
Replace Exceptions with an error metric and log

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -24,17 +24,36 @@ class FactorioCollector(prometheus_client.registry.Collector):
     def __init__(self: FactorioCollector, metrics_path: pathlib.Path) -> None:
         """Initialize the collector with the path to the metrics file."""
         self.metrics_path = metrics_path
-
+        
+    def __get_exporter_error_metric(_, is_error: bool) -> prometheus_client.metrics_core.GaugeMetricFamily:
+        return prometheus_client.metrics_core.GaugeMetricFamily(
+            "factorio_exporter_error",
+            "Indicates if there was an error collecting Factorio metrics.",
+            value=(1 if is_error else 0),
+        )    
+        
     def collect(self: FactorioCollector) -> None:  # noqa: C901 (will rework this soon)
         """Collect the Factorio metrics from the mod's output file."""
-        LOGGER.info(
-            "attempting to load metrics file output from mod: {}",
-            self.metrics_path,
-        )
-        with self.metrics_path.open(mode="r", encoding="utf-8") as f:
-            data = json.load(f)
+        LOGGER.info("Attempting to load metrics file output from mod: {}", self.metrics_path)
+        try:
+            with self.metrics_path.open(mode="r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            LOGGER.error("Metrics file not found: {}", self.metrics_path)
+            yield self.__get_exporter_error_metric(is_error=True)
+            return
+        except PermissionError:
+            LOGGER.error("Permission denied while reading file: {}", self.metrics_path)
+            yield self.__get_exporter_error_metric(is_error=True)
+            return
+        except json.JSONDecodeError:
+            LOGGER.error("Error while parsing JSON in metrics file: {}", self.metrics_path)
+            yield self.__get_exporter_error_metric(is_error=True)
+            return
+            
+        # Successfully loaded the Metrics file
         LOGGER.debug("<g>loaded metrics file output from mod</g>")
-
+        
         # Collect the current game tick.
         yield prometheus_client.metrics_core.GaugeMetricFamily(
             "factorio_game_tick",
@@ -173,6 +192,9 @@ class FactorioCollector(prometheus_client.registry.Collector):
             )
         yield rockets_launched_count
         yield items_launched_count
+        
+        # Indicate all metrics were gathered successfully
+        yield self.__get_exporter_error_metric(is_error=False)
 
 
 @click.group()


### PR DESCRIPTION
I love this mod, but I have one issue with it. Currently the exporter script doesn't catch file read exceptions, and will also write the entire stacktrace to STDOUT. This is a major problem since a newly created save file will not contain a metrics.json object, and will immediately throw a `FileNotFoundError` when the exporter is deployed. 

This can cause the container to fail, and Kubernetes will reschedule the pod (including the Factorio server itself). 

This handles these file read errors more gracefully, and provides a permanent record of them as a metric. 