### PR TITLE
RCON Implementation with fluid support and performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,14 @@ Below is a table of pollution-related metrics returned by this endpoint.
 | `factorio_pollution_consumption`   | `source`, `surface` | The current pollution consumption total for a given source on a surface. |
 | `factorio_pollution_production`    | `source`, `surface` | The current pollution production total for a given source on a surface.  |
 | `factorio_surface_pollution_total` | `surface`           | The total pollution across the surface.                                  |
+
+#### Electricity Networks Metrics
+
+The endpoint that returns electricity networks related metrics is located at `/metrics/electricity`.
+Below is a table of electricity-related metrics returned by this endpoint.
+
+| Metric                                   | Labels                       | Description                                                                      |
+| ---------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------- |
+| `factorio_electric_network_production`   | `entity`, `force`, `surface` | The average production for the past 10 minutes per ticks. (*60/1000000 for MW)   |
+| `factorio_electric_network_satisfaction` | `entity`, `force`, `surface` | The average satisfaction for the past 10 minutes per ticks. (*60/1000000 for MW) |
+| `factorio_electric_network_accumulator`  | `entity`, `force`, `surface` | The average accumulator charge for the past 10 minutes (/1000000 for MJ)         |

--- a/collection/collectors.py
+++ b/collection/collectors.py
@@ -284,11 +284,11 @@ class FactorioProductionCollector(FactorioCollector):
                 prototypes = surface_force_data["prototypes"]
                 for prototype, prototype_data in prototypes.items():
                     force_consumption_stats.add_metric(
-                        labels=[force, prototype, surface, prototype_data["type"]],
+                        labels=[force, prototype, surface],
                         value=prototype_data["consumption"],
                     )
                     force_production_stats.add_metric(
-                        labels=[force, prototype, surface, prototype_data["type"]],
+                        labels=[force, prototype, surface],
                         value=prototype_data["production"],
                     )
 

--- a/collection/collectors.py
+++ b/collection/collectors.py
@@ -369,3 +369,51 @@ class FactorioPollutionCollector(FactorioCollector):
         yield surface_pollution_total_stats
         yield surface_pollution_consumption
         yield surface_pollution_production
+
+class FactorioElectricNetworkStatistics(FactorioCollector):
+    """Represents a collector that collect metrics related to electric networks in the Factorio server."""
+
+    def __init__(self, client: RCONClient) -> None:
+        """Initialize the electric network metrics collector."""
+        super().__init__(client=client, group="electricity")
+
+    def collect(self) -> Generator[Any, Any, Any]:
+        """Collect the metrics and store them in the Prometheus collector."""
+        metrics = self.metrics
+        surface_electric_network_production = GaugeMetricFamily(
+            name="factorio_electric_network_production",
+            documentation="The production of electricity for the past 10 minutes for a given prototype on a surface.",
+            labels=["force", "surface", "entity"],
+        )
+        surface_electric_network_satisfaction = GaugeMetricFamily(
+            name="factorio_electric_network_satisfaction",
+            documentation="The satisfaction of electricity for the past 10 minutes for a given prototype on a surface.",
+            labels=["force", "surface", "entity"],
+        )
+        surface_electric_network_accumulator = GaugeMetricFamily(
+            name="factorio_electric_network_accumulator",
+            documentation="The accumulator charge for the past 10 minutes on a given surface.",
+            labels=["force", "surface", "entity"],
+        )
+
+        for force, force_data in metrics["forces"].items():
+            for surface, surface_force_data in force_data.items():
+                for entity, entity_data in surface_force_data["production"].items():
+                    surface_electric_network_production.add_metric(
+                        labels=[force, surface, entity],
+                        value= entity_data,
+                    )
+                for entity, entity_data in surface_force_data["satisfaction"].items():
+                    surface_electric_network_satisfaction.add_metric(
+                        labels=[force, surface, entity],
+                        value= entity_data,
+                    )
+                for entity, entity_data in surface_force_data["accumulator_charge"].items():
+                    surface_electric_network_accumulator.add_metric(
+                            labels=[force, surface, entity],
+                            value= entity_data,
+                    )
+
+        yield surface_electric_network_production
+        yield surface_electric_network_satisfaction
+        yield surface_electric_network_accumulator

--- a/collection/collectors.py
+++ b/collection/collectors.py
@@ -271,12 +271,12 @@ class FactorioProductionCollector(FactorioCollector):
         force_consumption_stats = CounterMetricFamily(
             name="factorio_force_prototype_consumption",
             documentation="The total consumption of a given prototype for a force.",
-            labels=["force", "prototype", "surface", "type"],
+            labels=["force", "prototype", "surface"],
         )
         force_production_stats = CounterMetricFamily(
             name="factorio_force_prototype_production",
             documentation="The total production of a given prototype for a force.",
-            labels=["force", "prototype", "surface", "type"],
+            labels=["force", "prototype", "surface"],
         )
 
         for force, force_data in metrics["forces"].items():

--- a/collection/lua/electricity.lua
+++ b/collection/lua/electricity.lua
@@ -1,0 +1,75 @@
+-- Lua script to be sent along as an RCON command to gather statistics and
+-- report back metrics on the given world.
+local response = {}
+response["status"] = 200
+
+local metrics = {}
+metrics["forces"] = {}
+metrics["forces"]["player"] = {}
+
+for _, surface in pairs(game.surfaces) do
+
+  -- Collect metrics on electric networks.
+  metrics["forces"]["player"][surface.name] = {}
+  -- Gather the electric pole type. Will return all poles type on the surface.
+  local entities_planets = surface.find_entities_filtered({force = "player", type = {"electric-pole"}})
+
+  -- Gather the platforms entities for space platforms electricity networks.
+  local entities_platform = surface.find_entities_filtered({force = "player", type = {"space-platform-hub"}})
+
+  -- Get the first electric pole type entity on the surface.
+  if entities_planets[1] ~= nil then
+    -- Every electric pole return the same electric network statistics on the surfaces.
+    local electric_network = entities_planets[1].electric_network_statistics
+    metrics["forces"]["player"][surface.name]["production"] = {}
+    metrics["forces"]["player"][surface.name]["satisfaction"] = {}
+    metrics["forces"]["player"][surface.name]["accumulator_charge"] = {}
+
+    -- Collect the electric network statistics for the surface.
+    for i, _ in pairs(electric_network.output_counts) do
+      if i ~= nil then
+        -- Returns the 10 minutes electric network production statistics. It returns the value for ticks, so you need to multiply it by 60 to get the value per minute.
+        metrics["forces"]["player"][surface.name]["production"][i] = electric_network.get_flow_count{name=i, category="output", input=true, precision_index=defines.flow_precision_index.ten_minutes}
+      end
+    end
+    for i, _ in pairs(electric_network.input_counts) do
+      if i ~= nil then
+        -- Returns the 10 minutes electric network satisfaction statistics. It returns the value for ticks, so you need to multiply it by 60 to get the value per minute.
+        metrics["forces"]["player"][surface.name]["satisfaction"][i] = electric_network.get_flow_count{name=i, category="input", input=true, precision_index=defines.flow_precision_index.ten_minutes}
+      end
+    end
+    for i, _ in pairs(electric_network.storage_counts) do
+      if i ~= nil then
+        -- Returns the 10 minutes electric network accumulator charge statistics. It returns the value for ticks, so you need to multiply it by 60 to get the value per minute.
+        metrics["forces"]["player"][surface.name]["accumulator_charge"][i] = electric_network.get_flow_count{name=i, category="storage", input=true, precision_index=defines.flow_precision_index.ten_minutes}
+      end
+    end
+  end
+
+  -- Returns the samething as planets but for space platforms.
+  if entities_platform[1] ~= nil then
+    -- The network statistics is only accessible through the global electric network statistics.
+    local electric_network = surface.global_electric_network_statistics
+    metrics["forces"]["player"][surface.name]["production"] = {}
+    metrics["forces"]["player"][surface.name]["satisfaction"] = {}
+    metrics["forces"]["player"][surface.name]["accumulator_charge"] = {}
+    for i, _ in pairs(electric_network.output_counts) do
+      if i ~= nil then
+        metrics["forces"]["player"][surface.name]["production"][i] = electric_network.get_flow_count{name=i, category="output", input=true, precision_index=defines.flow_precision_index.ten_minutes}
+      end
+    end
+    for i, _ in pairs(electric_network.input_counts) do
+      if i ~= nil then
+        metrics["forces"]["player"][surface.name]["satisfaction"][i] = electric_network.get_flow_count{name=i, category="input", input=true, precision_index=defines.flow_precision_index.ten_minutes}
+      end
+    end
+    for i, _ in pairs(electric_network.storage_counts) do
+      if i ~= nil then
+        metrics["forces"]["player"][surface.name]["accumulator_charge"][i] = electric_network.get_flow_count{name=i, category="storage", input=true, precision_index=defines.flow_precision_index.ten_minutes}
+      end
+    end
+  end
+end
+
+response["metrics"] = metrics
+rcon.print(helpers.table_to_json(response))

--- a/collection/lua/launches.lua
+++ b/collection/lua/launches.lua
@@ -12,8 +12,8 @@ for _, force in pairs(game.forces) do
   metrics["forces"][force.name]["launches"] = {}
   metrics["forces"][force.name]["launches"]["count"] = game.forces[force.name].rockets_launched  
   metrics["forces"][force.name]["launches"]["items"] = {}
-  for _, item in pairs(game.forces[force.name].items_launched) do
-    metrics["forces"][force.name]["launches"]["items"][item.name] = item.count
+  for item, count in pairs(game.forces[force.name].items_launched) do
+    metrics["forces"][force.name]["launches"]["items"][item] = count
   end
 end
 

--- a/collection/lua/production.lua
+++ b/collection/lua/production.lua
@@ -10,6 +10,8 @@ for _, force in pairs(game.forces) do
   metrics["forces"][force.name] = {}
   for _, surface in pairs(game.surfaces) do
     metrics["forces"][force.name][surface.name] = {}
+
+    -- Collect metrics on production and consumption of item and fluid.
     metrics["forces"][force.name][surface.name]["prototypes"] = {}
     local production = game.forces[force.name].get_item_production_statistics(surface.name)
     local totals = production.input_counts

--- a/collection/lua/production.lua
+++ b/collection/lua/production.lua
@@ -9,15 +9,21 @@ metrics["forces"] = {}
 for _, force in pairs(game.forces) do
   metrics["forces"][force.name] = {}
   for _, surface in pairs(game.surfaces) do
-    -- Collect metrics on prototype production and consumption for the given force and surface.
     metrics["forces"][force.name][surface.name] = {}
     metrics["forces"][force.name][surface.name]["prototypes"] = {}
     local production = game.forces[force.name].get_item_production_statistics(surface.name)
-    for _, item in pairs(prototypes.item) do
-      metrics["forces"][force.name][surface.name]["prototypes"][item.name] = {}
-      metrics["forces"][force.name][surface.name]["prototypes"][item.name]["production"] = production.get_input_count(item.name)
-      metrics["forces"][force.name][surface.name]["prototypes"][item.name]["consumption"] = production.get_output_count(item.name)
-      metrics["forces"][force.name][surface.name]["prototypes"][item.name]["type"] = item.type
+    local totals = production.input_counts
+    for item_name, _ in pairs(totals) do
+      metrics["forces"][force.name][surface.name]["prototypes"][item_name] = {}
+      metrics["forces"][force.name][surface.name]["prototypes"][item_name]["production"] = production.get_input_count(item_name)
+      metrics["forces"][force.name][surface.name]["prototypes"][item_name]["consumption"] = production.get_output_count(item_name)
+    end
+    local fluid_production = game.forces[force.name].get_fluid_production_statistics(surface.name)
+    local fluid_totals = fluid_production.input_counts
+    for item_name, _ in pairs(fluid_totals) do
+      metrics["forces"][force.name][surface.name]["prototypes"][item_name] = {}
+      metrics["forces"][force.name][surface.name]["prototypes"][item_name]["production"] = fluid_production.get_input_count(item_name)
+      metrics["forces"][force.name][surface.name]["prototypes"][item_name]["consumption"] = fluid_production.get_output_count(item_name)
     end
   end
 end

--- a/exporter.py
+++ b/exporter.py
@@ -26,6 +26,7 @@ from collection.collectors import (
     FactorioProductionCollector,
     FactorioResearchCollector,
     FactorioTimeCollector,
+    FactorioElectricNetworkStatistics,
 )
 
 LOGGER = loguru.logger.opt(colors=True)
@@ -115,6 +116,7 @@ def run(metrics_port: int, rcon_address: str, rcon_port: int, rcon_password: str
         FactorioProductionCollector(client=client),
         FactorioEntityCollector(client=client),
         FactorioPollutionCollector(client=client),
+        FactorioElectricNetworkStatistics(client=client),
     ]
 
     for collector in collectors:


### PR DESCRIPTION
This is to add to the RCON implementation.

1. Removing prototype_type, as after experimenting, I am not too sure what it is useful for.
2. Adding support for fluid metrics since the `get_item_production_statistics` does not include fluids.
3. Instead of looping through every item of the game for metrics, I am just looping through the items shown in the production and giving any item produced on the surface for the whole game. This is inspired by: `https://wiki.factorio.com/console#Exporting_production_statistics`
4. Adding electricity metrics and the documentation

Feel free to reject :) But this reduce considerably the amount of FPS/UPS in the endgame. I am losing 1-2 now instead of 15 prior to the change. Keep in mind I am running everything locally in a Kubernetes cluster with Kind.